### PR TITLE
Update pre-commit GitHub action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,12 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
-    - name: set PY
-      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v1.1.0
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,6 @@ repos:
     -   id: pyupgrade
         args: [--py36-plus]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.770
+    rev: v0.800
     hooks:
     -   id: mypy


### PR DESCRIPTION
This change ensures that we can run pre-commit in CI. 

`set-env` is now discouraged because of:
```
Error: Unable to process command '::set-env name=PY::1453f75cdbef9e7a53ef361293b38c015cbc84ebad668b2f8bda87df40335b44' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

So instead I am updating the config to mirror the change in https://github.com/pre-commit/action/pull/31

Further, mypy fails with a slew of

```
unkey.py:26: error: syntax error in type comment
unkey.py:33: error: syntax error in type comment
unkey.py:76: error: syntax error in type comment
```

This issue is tracked in https://github.com/python/mypy/issues/8872 and updating mypy fixes that issue